### PR TITLE
Add a Nix derivation for the lucky few.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,34 @@
+{ pkgs ? import <nixpkgs> {},
+}:
+
+pkgs.stdenv.mkDerivation rec {
+  name = "smlpkg";
+
+  src = ./.;
+
+  nativeBuildInputs = [ pkgs.mlton ];
+
+  checkInputs = [ pkgs.unzip ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  # Set as an environment variable in all the phase scripts.
+  MLCOMP = "mlton";
+
+  buildPhase = ''
+    make all
+  '';
+
+  installPhase = ''
+    make install prefix=$out
+  '';
+
+  # We cannot run the pkgtests, as Nix does not allow network
+  # connections.
+  checkPhase = ''
+    make -C src test
+  '';
+
+}


### PR DESCRIPTION
With this in place, anyone with Nix can compile `smlpkg` just by running `nix-build` (`mlton` will be made available automatically).