### PR TITLE
Pzel add two pzel packages to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ to their own source code tree using `smlpkg add` (see above).
   [github.com/diku-dk/sml-unicode](https://github.com/diku-dk/sml-unicode)
 * [![CI](https://github.com/diku-dk/sml-uref/workflows/CI/badge.svg)](https://github.com/diku-dk/sml-uref/actions)
   [github.com/diku-dk/sml-uref](https://github.com/diku-dk/sml-uref)
+* [github.com/pzel/assert-polyml](https://github.com/pzel/assert-polyml)
 * [github.com/shwestrick/sml-audio](https://github.com/shwestrick/sml-audio)
 * [github.com/shwestrick/sml-uri](https://github.com/shwestrick/sml-uri)
 * [github.com/shwestrick/sml-parseq](https://github.com/shwestrick/sml-parseq)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ to their own source code tree using `smlpkg add` (see above).
 * [![CI](https://github.com/diku-dk/sml-uref/workflows/CI/badge.svg)](https://github.com/diku-dk/sml-uref/actions)
   [github.com/diku-dk/sml-uref](https://github.com/diku-dk/sml-uref)
 * [github.com/pzel/assert-polyml](https://github.com/pzel/assert-polyml)
+* [github.com/pzel/sqlite3-polyml](https://github.com/pzel/sqlite3-polyml)
 * [github.com/shwestrick/sml-audio](https://github.com/shwestrick/sml-audio)
 * [github.com/shwestrick/sml-uri](https://github.com/shwestrick/sml-uri)
 * [github.com/shwestrick/sml-parseq](https://github.com/shwestrick/sml-parseq)


### PR DESCRIPTION
I converted two of my hobby Poly/ML projects to use [polymlb](https://github.com/vqns/polymlb) as a build system, and use a project structure compatible with `smlpkg`.

In the hope that the work is useful to users of `smlpkg` on Poly/ML, I'd like to include my projects in the README.