### PR TITLE
Add pzel/sml-either to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ to their own source code tree using `smlpkg add` (see above).
 * [![CI](https://github.com/diku-dk/sml-uref/workflows/CI/badge.svg)](https://github.com/diku-dk/sml-uref/actions)
   [github.com/diku-dk/sml-uref](https://github.com/diku-dk/sml-uref)
 * [github.com/pzel/assert-polyml](https://github.com/pzel/assert-polyml)
+* [github.com/pzel/sml-either](https://github.com/pzel/sml-either)
 * [github.com/pzel/sqlite3-polyml](https://github.com/pzel/sqlite3-polyml)
 * [github.com/shwestrick/sml-audio](https://github.com/shwestrick/sml-audio)
 * [github.com/shwestrick/sml-uri](https://github.com/shwestrick/sml-uri)


### PR DESCRIPTION
I added John Reppy's 2015 Basis extension proposal (https://github.com/SMLFamily/BasisLibrary/wiki/2015-002-Addition-of-Either-module) as an smlpkg. I hope it'll be of use to someone.