### PR TITLE
Report when package dir doesn't exist instead of silently raising ENOENT

### DIFF
--- a/src/pkg.sml
+++ b/src/pkg.sml
@@ -249,9 +249,8 @@ struct
           | SOME pkgpath =>
               let
                 val pdir = "lib" </> Manifest.pkgpathToString pkgpath
-                val pdir_exists = OS.FileSys.isDir pdir
               in
-                if pdir_exists then ()
+                if System.doesDirExist pdir then ()
                 else raise Fail ("the directory " ^ pdir ^ " does not exist.")
               end
         end


### PR DESCRIPTION
Currently `doCheck` fails with an unhandled SysErr (ENOENT) when the package dir does not exist in `lib`. This is confusing as there is no user-facing information about what's going on. I figured this out by printf-debugging.

By replacing Os.FileSys.isDir with the non-raising System.doesDirExist, the issue is solved and the error is printed out nicely for the user.